### PR TITLE
Re-organize project structure and add more mock methods

### DIFF
--- a/lib/src/firebase_storage_mocks_base.dart
+++ b/lib/src/firebase_storage_mocks_base.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:mockito/mockito.dart';
@@ -14,7 +15,7 @@ class MockFirebaseStorage extends Mock implements FirebaseStorage {
 
 class MockStorageReference extends Mock implements StorageReference {
   final String _path;
-  final Map<String, MockStorageReference> children = Map();
+  final Map<String, MockStorageReference> children = {};
   File storedFile;
 
   MockStorageReference([this._path = '']);
@@ -30,6 +31,11 @@ class MockStorageReference extends Mock implements StorageReference {
   @override
   StorageUploadTask putFile(File file, [StorageMetadata metadata]) {
     storedFile = file;
+    return MockStorageUploadTask();
+  }
+
+  @override
+  StorageUploadTask putData(Uint8List data, [StorageMetadata metadata]) {
     return MockStorageUploadTask();
   }
 

--- a/lib/src/firebase_storage_mocks_base.dart
+++ b/lib/src/firebase_storage_mocks_base.dart
@@ -40,6 +40,11 @@ class MockStorageReference extends Mock implements StorageReference {
   }
 
   @override
+  Future<void> delete() {
+    return Future.value();
+  }
+
+  @override
   String get path => _path;
 
   @override

--- a/lib/src/firebase_storage_mocks_base.dart
+++ b/lib/src/firebase_storage_mocks_base.dart
@@ -1,62 +1,34 @@
 import 'dart:io';
 import 'dart:typed_data';
-
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:firebase_storage_mocks/src/mock_storage_reference.dart';
 import 'package:mockito/mockito.dart';
 
 class MockFirebaseStorage extends Mock implements FirebaseStorage {
-  final _ref = MockStorageReference();
+  final Map<String, File> storedFilesMap = {};
+  final Map<String, Uint8List> storedDataMap = {};
 
   @override
   StorageReference ref() {
-    return _ref;
-  }
-}
-
-class MockStorageReference extends Mock implements StorageReference {
-  final String _path;
-  final Map<String, MockStorageReference> children = {};
-  File storedFile;
-
-  MockStorageReference([this._path = '']);
-
-  @override
-  StorageReference child(String path) {
-    if (!children.containsKey(path)) {
-      children[path] = MockStorageReference('$_path/$path');
-    }
-    return children[path];
-  }
-
-  @override
-  StorageUploadTask putFile(File file, [StorageMetadata metadata]) {
-    storedFile = file;
-    return MockStorageUploadTask();
-  }
-
-  @override
-  StorageUploadTask putData(Uint8List data, [StorageMetadata metadata]) {
-    return MockStorageUploadTask();
-  }
-
-  @override
-  Future<void> delete() {
-    return Future.value();
-  }
-
-  @override
-  String get path => _path;
-
-  @override
-  Future<String> getBucket() {
-    return Future.value('some-bucket');
+    return MockStorageReference(this);
   }
 }
 
 class MockStorageUploadTask extends Mock implements StorageUploadTask {
+  final StorageReference reference;
+
+  MockStorageUploadTask(this.reference);
+
   @override
   Future<StorageTaskSnapshot> get onComplete =>
-      Future.value(MockStorageTaskSnapshot());
+      Future.value(MockStorageTaskSnapshot(reference));
 }
 
-class MockStorageTaskSnapshot extends Mock implements StorageTaskSnapshot {}
+class MockStorageTaskSnapshot extends Mock implements StorageTaskSnapshot {
+  final StorageReference reference;
+
+  MockStorageTaskSnapshot(this.reference);
+
+  @override
+  StorageReference get ref => reference;
+}

--- a/lib/src/mock_storage_reference.dart
+++ b/lib/src/mock_storage_reference.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:firebase_storage_mocks/firebase_storage_mocks.dart';
+import 'package:mockito/mockito.dart';
+
+class MockStorageReference extends Mock implements StorageReference {
+  final MockFirebaseStorage _storage;
+  final String _path;
+  final Map<String, MockStorageReference> children = {};
+
+  MockStorageReference(this._storage, [this._path = '']);
+
+  @override
+  StorageReference child(String path) {
+    if (!children.containsKey(path)) {
+      children[path] = MockStorageReference(_storage, '$_path/$path');
+    }
+    return children[path];
+  }
+
+  @override
+  StorageUploadTask putFile(File file, [StorageMetadata metadata]) {
+    _storage.storedFilesMap[_path] = file;
+    return MockStorageUploadTask(this);
+  }
+
+  @override
+  StorageUploadTask putData(Uint8List data, [StorageMetadata metadata]) {
+    _storage.storedDataMap[_path] = data;
+    return MockStorageUploadTask(this);
+  }
+
+  @override
+  Future<void> delete() {
+    if (_storage.storedFilesMap.containsKey(_path)) {
+      _storage.storedFilesMap.remove(_path);
+    }
+    if (_storage.storedDataMap.containsKey(_path)) {
+      _storage.storedDataMap.remove(_path);
+    }
+    return Future.value();
+  }
+
+  @override
+  String get path => _path;
+
+  @override
+  Future<String> getBucket() => Future.value('some-bucket');
+
+  @override
+  Future<String> getPath() => Future.value(_path);
+
+  @override
+  Future<String> getName() => Future.value(_path.split('/').last);
+
+  @override
+  FirebaseStorage getStorage() => _storage;
+
+  @override
+  StorageReference getRoot() => MockStorageReference(_storage);
+}

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:firebase_storage_mocks/firebase_storage_mocks.dart';
@@ -13,10 +14,23 @@ void main() {
     final image = File(filename);
     final task = storageRef.putFile(image);
     await task.onComplete;
-    expect(await getGsLink(storageRef), equals('gs://some-bucket//someimage.png'));
+    expect(await getGsLink(storageRef), equals('gs://some-bucket/someimage.png'));
+  });
+
+  test('Puts Data', () async {
+    final storage = MockFirebaseStorage();
+    final storageRef = storage.ref().child(filename);
+    final imageData = Uint8List(256);
+    final task = storageRef.putData(imageData);
+    await task.onComplete;
+    expect(await getGsLink(storageRef), equals('gs://some-bucket/someimage.png'));
   });
 }
 
 Future<String> getGsLink(StorageReference storageRef) async {
-  return 'gs://' + await storageRef.getBucket() + '/' + storageRef.path;
+  return Uri(
+    scheme: 'gs',
+    host: await storageRef.getBucket(),
+    path: storageRef.path,
+  ).toString();
 }

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -8,22 +8,35 @@ import 'package:test/test.dart';
 final filename = 'someimage.png';
 
 void main() {
-  test('Puts File', () async {
-    final storage = MockFirebaseStorage();
-    final storageRef = storage.ref().child(filename);
-    final image = File(filename);
-    final task = storageRef.putFile(image);
-    await task.onComplete;
-    expect(await getGsLink(storageRef), equals('gs://some-bucket/someimage.png'));
-  });
+  group('MockFirebaseStorage Tests', () {
+    MockFirebaseStorage storage;
 
-  test('Puts Data', () async {
-    final storage = MockFirebaseStorage();
-    final storageRef = storage.ref().child(filename);
-    final imageData = Uint8List(256);
-    final task = storageRef.putData(imageData);
-    await task.onComplete;
-    expect(await getGsLink(storageRef), equals('gs://some-bucket/someimage.png'));
+    setUpAll(() {
+      storage = MockFirebaseStorage();
+    });
+
+    test('Puts File', () async {
+      final storageRef = storage.ref().child(filename);
+      final image = File(filename);
+      final task = storageRef.putFile(image);
+      final snap = await task.onComplete;
+
+      expect(await getGsLink(snap.ref),
+          equals('gs://some-bucket/someimage.png'));
+      expect(storage.storedFilesMap.containsKey('/$filename'), isTrue);
+    });
+
+    test('Puts Data', () async {
+      final storage = MockFirebaseStorage();
+      final storageRef = storage.ref().child(filename);
+      final imageData = Uint8List(256);
+      final task = storageRef.putData(imageData);
+      final snap = await task.onComplete;
+
+      expect(await getGsLink(snap.ref),
+          equals('gs://some-bucket/someimage.png'));
+      expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
+    });
   });
 }
 


### PR DESCRIPTION
This PR will split the `MockStorageReference` in his own file and mock more methods. When using `MockFirebaseStorage` it's now possible to emulate the data storing and deletion process.

- [x] mock `putData`
- [x] mock `delete`
- [x] mock getters like `getPath` and `getStorage`
- [x] let `MockStorageTaskSnapshot` return a valid `ref`
- [ ] mock methods to retrieve data from a `StorageReference`
