### PR TITLE
Typo: fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@ Mocks for [Firebase Storage](https://pub.dev/packages/firebase_storage). Use thi
 
 ## Usage
 
-A simple usage example:
-
+A simple usage example: (assumes `assets/someimage.png` exists in project and is included in assets section of pubspec.yaml)
 ```dart
 import 'package:firebase_storage_mocks/firebase_storage_mocks.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
-main() {
-  final storage = MockFirebaseStorage('someimage.png');
+main() async {
+  final storage = MockFirebaseStorage();
+  const filename = 'someimage.png';
   final storageRef = storage.ref().child(filename);
-  final image = File(filename);
-  await storageRef.putFile(image);
+  final localImage = await rootBundle.load("assets/$filename");
+  final task = await storageRef.putData(localImage.buffer.asUint8List());
   // Prints 'gs://some-bucket//someimage.png'.
-  print(task.snapshot.ref.fullPath);
+  print(task.ref.fullPath);
 }
 ```
 


### PR DESCRIPTION
Fixed errors in README.md **Usage** example
* `MockFirebaseStorage` was being passed a string parameter.
* `filename` wasn't declared
* `task` wasn't declared
* `main()` wasn't `async` but used `await`

Addition changes include using `putData` (replacing `putFile`) to load `.png` from `assets`, this was just preference, but made it more universal as no need to import `File`.