### PR TITLE
Use memory file system when running unit tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,5 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  file: ^6.1.2
   pedantic: ^1.0.0
   test: ^1.16.5

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file/memory.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:firebase_storage_mocks/firebase_storage_mocks.dart';
 import 'package:test/test.dart';
@@ -9,12 +10,10 @@ final filename = 'someimage.png';
 
 void main() {
   group('MockFirebaseStorage Tests', () {
-
     test('Puts File', () async {
       final storage = MockFirebaseStorage();
       final storageRef = storage.ref().child(filename);
-      final image = File(filename);
-      final task = storageRef.putFile(image);
+      final task = storageRef.putFile(getFakeImageFile());
       await task;
 
       expect(
@@ -37,8 +36,7 @@ void main() {
     test('Set, get and update metadata', () async {
       final storage = MockFirebaseStorage();
       final storageRef = storage.ref().child(filename);
-      final image = File(filename);
-      final task = storageRef.putFile(image);
+      final task = storageRef.putFile(getFakeImageFile());
       await task;
       await storageRef.updateMetadata(SettableMetadata(
         cacheControl: 'public,max-age=300',
@@ -64,8 +62,16 @@ void main() {
       ));
       final metadata2 = await storageRef.getMetadata();
       expect(metadata2.cacheControl == 'max-age=60', true);
+
       ///Old informations persist over updates
       expect(metadata2.contentType == 'image/jpeg', true);
     });
   });
+}
+
+File getFakeImageFile() {
+  var fs = MemoryFileSystem();
+  final image = fs.file(filename);
+  image.writeAsStringSync('contents');
+  return image;
 }


### PR DESCRIPTION
This fixes errors in unit tests introduced in #12 ([link](https://github.com/atn832/firebase_storage_mocks/runs/7128284130?check_suite_focus=true)):
```
  FileSystemException: Cannot retrieve length of file, path = 'someimage.png' (OS Error: No such file or directory, errno = 2)
  dart:io                                                                _File.lengthSync
  package:firebase_storage_mocks/src/mock_storage_reference.dart 105:90  MockReference._createFullMetadata
  package:firebase_storage_mocks/src/mock_storage_reference.dart 26:38   MockReference.putFile
```

Instead of referring to a file on the file system which does not exist, we use the memory file system to set up a file with actual data.