### PR TITLE
Store only settable metadata

### DIFF
--- a/lib/src/firebase_storage_mocks_base.dart
+++ b/lib/src/firebase_storage_mocks_base.dart
@@ -9,7 +9,7 @@ import 'package:mockito/mockito.dart';
 class MockFirebaseStorage extends Mock implements FirebaseStorage {
   final Map<String, File> storedFilesMap = {};
   final Map<String, Uint8List> storedDataMap = {};
-  final Map<String, FullMetadata> storedMetadata = {};
+  final Map<String, Map<String, dynamic>> storedSettableMetadataMap = {};
 
   @override
   Reference ref([String? path]) {


### PR DESCRIPTION
Implements what I suggested in https://github.com/atn832/firebase_storage_mocks/pull/12/files#r910788762. I believe the code is more readable than in #12 since:
- it explicitly shows that generated metadata can't ever be modified.
- when returning full metadata, we simply return the generated metadata with the settable metadata on top.