### PR TITLE
Added reference to original firestore code

### DIFF
--- a/lib/src/firebase_storage_mocks_base.dart
+++ b/lib/src/firebase_storage_mocks_base.dart
@@ -18,6 +18,7 @@ class MockFirebaseStorage extends Mock implements FirebaseStorage {
     return MockReference(this, path);
   }
 
+  // Originally from https://github.com/firebase/flutterfire/blob/3dfc0997050ee4351207c355b2c22b46885f971f/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart#L111.
   @override
   Reference refFromURL(String url) {
     assert(url.startsWith('gs://') || url.startsWith('http'),

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,3 +1,5 @@
+// Originally from https://github.com/firebase/flutterfire/blob/master/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+
 /// Returns a path from a given `gs://` URL.
 ///
 /// If no path exists, the root path will be returned.


### PR DESCRIPTION
Add reference to the original firestore code in code introduced in #17, so that we can keep it in sync if the original repository changes.