### PR TITLE
Modified to disappear in conjunction with parent references.

### DIFF
--- a/lib/src/mock_storage_reference.dart
+++ b/lib/src/mock_storage_reference.dart
@@ -35,14 +35,36 @@ class MockReference implements Reference {
 
   @override
   Future<void> delete() {
-    if (_storage.storedFilesMap.containsKey(_path)) {
-      _storage.storedFilesMap.remove(_path);
+    var key = '';
+    for (var e in _storage.storedFilesMap.entries) {
+      if (e.key.startsWith(_path)) {
+        key = e.key;
+        break;
+      }
     }
-    if (_storage.storedDataMap.containsKey(_path)) {
-      _storage.storedDataMap.remove(_path);
+    if (key != '') {
+      _storage.storedFilesMap.remove(key);
     }
-    if (_storage.storedSettableMetadataMap.containsKey(_path)) {
-      _storage.storedSettableMetadataMap.remove(_path);
+    key = '';
+    for (var e in _storage.storedDataMap.entries) {
+      if (e.key.startsWith(_path)) {
+        key = e.key;
+        break;
+      }
+    }
+    if (key != '') {
+      _storage.storedDataMap.remove(key);
+    }
+
+    key = '';
+    for (var e in _storage.storedSettableMetadataMap.entries) {
+      if (e.key.startsWith(_path)) {
+        key = e.key;
+        break;
+      }
+    }
+    if (key != '') {
+      _storage.storedSettableMetadataMap.remove(key);
     }
     return Future.value();
   }

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -96,6 +96,24 @@ void main() {
       expect(
           storage.storedSettableMetadataMap.containsKey('/$filename'), isFalse);
     });
+    test('Delete Parent', () async {
+      final storage = MockFirebaseStorage();
+      final parentRef = storage.ref().child('parent');
+      final storageRef = parentRef.child(filename);
+      final imageData = Uint8List(256);
+      final task = storageRef.putData(imageData);
+      await task;
+      expect(task.snapshot.ref.fullPath,
+          equals('gs://some-bucket/parentsomeimage.png'));
+
+      expect(storage.storedDataMap.containsKey('/parent$filename'), isTrue);
+      expect(storage.storedSettableMetadataMap.containsKey('/parent$filename'),
+          isTrue);
+      await parentRef.delete();
+      expect(storage.storedDataMap.containsKey('/parent$filename'), isFalse);
+      expect(storage.storedSettableMetadataMap.containsKey('/parent$filename'),
+          isFalse);
+    });
   });
 }
 

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -79,6 +79,23 @@ void main() {
       ///Old informations persist over updates
       expect(metadata2.contentType, equals('image/jpeg'));
     });
+    test('Delete File', () async {
+      final storage = MockFirebaseStorage();
+      final storageRef = storage.ref().child(filename);
+      final imageData = Uint8List(256);
+      final task = storageRef.putData(imageData);
+      await task;
+
+      expect(
+          task.snapshot.ref.fullPath, equals('gs://some-bucket/someimage.png'));
+      expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
+      expect(
+          storage.storedSettableMetadataMap.containsKey('/$filename'), isTrue);
+      await storageRef.delete();
+      expect(storage.storedDataMap.containsKey('/$filename'), isFalse);
+      expect(
+          storage.storedSettableMetadataMap.containsKey('/$filename'), isFalse);
+    });
   });
 }
 


### PR DESCRIPTION
When a parent reference is deleted, child references are also deleted.
Add a test to verify the above


The test was not supported because adding files seemed to be unimplemented. :(