### PR TITLE
Fixed null safety error in getData()

### DIFF
--- a/lib/src/mock_storage_reference.dart
+++ b/lib/src/mock_storage_reference.dart
@@ -85,7 +85,7 @@ class MockReference implements Reference {
   }
 
   @override
-  Future<Uint8List> getData([int maxSize = 10485760]) {
+  Future<Uint8List?> getData([int maxSize = 10485760]) {
     return Future.value(_storage.storedDataMap[_path]);
   }
 

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:file/memory.dart';
@@ -31,6 +32,27 @@ void main() {
       expect(
           task.snapshot.ref.fullPath, equals('gs://some-bucket/someimage.png'));
       expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
+    });
+
+    group('Gets Data', () {
+      late MockFirebaseStorage storage;
+      late Reference reference;
+      final imageData = Uint8List(256);
+      setUp(() async {
+        storage = MockFirebaseStorage();
+        reference = storage.ref().child(filename);
+        final task = reference.putData(imageData);
+        await task;
+      });
+      test('for valid reference', () async {
+        final data = await reference.getData();
+        expect(data, imageData);
+      });
+      test('for invalid reference', () async {
+        final invalidReference = reference.child("invalid");
+        final data = await invalidReference.getData();
+        expect(data, isNull);
+      });
     });
 
     test('Get download url', () async {

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:file/memory.dart';


### PR DESCRIPTION
When attempting to call the `getData()` method on a nonexistent `Reference` a CastError is currently thrown due to the method erroneously having a non-nullable type while the original library allows for null to be returned. This PR fixes this problem, so that for example getting the data of a file that wasn't written yet can be unit tested properly.