### PR TITLE
add checks to getDownloadURL() function

### DIFF
--- a/lib/src/mock_storage_reference.dart
+++ b/lib/src/mock_storage_reference.dart
@@ -92,8 +92,18 @@ class MockReference implements Reference {
   @override
   Future<String> getDownloadURL() {
     final path = _path.startsWith('/') ? _path : '/$_path';
-    return Future.value(
-        'https://firebasestorage.googleapis.com/v0/b/$bucket/o$path');
+
+    if (_storage.storedFilesMap.containsKey(_path) ||
+        _storage.storedDataMap.containsKey(_path) ||
+        _storage.storedSettableMetadataMap.containsKey(_path)) {
+      return Future.value(
+          'https://firebasestorage.googleapis.com/v0/b/$bucket/o$path');
+    } else {
+      throw FirebaseException(
+          plugin: 'firebase_storage',
+          message: 'No object exists at the desired reference.',
+          code: 'object-not-found');
+    }
   }
 
   @override

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -70,17 +70,42 @@ void main() {
 
     test('Get download url', () async {
       final storage = MockFirebaseStorage();
-      final downloadUrl = await storage.ref('/some/path').getDownloadURL();
+      final storageRef = storage.ref('/some/path').child(filename);
+      final task = storageRef.putFile(getFakeImageFile());
+      await task;
+      final downloadUrl = await storageRef.getDownloadURL();
       expect(downloadUrl.startsWith('http'), isTrue);
       expect(downloadUrl.contains('/some/path'), isTrue);
     });
 
     test('Ref from url', () async {
       final storage = MockFirebaseStorage();
-      final downloadUrl = await storage.ref('/some/path').getDownloadURL();
+      final storageRef = storage.ref('/some/path').child(filename);
+      final task = storageRef.putFile(getFakeImageFile());
+      await task;
+      final downloadUrl = await storageRef.getDownloadURL();
       final ref = storage.refFromURL(downloadUrl);
       expect(ref, isA<Reference>());
     });
+
+    test(
+      'Delete File',
+      () async {
+        final storage = MockFirebaseStorage();
+        final storageRef = storage.ref().child(filename);
+        final task = storageRef.putFile(getFakeImageFile());
+        await task;
+        final url = await storageRef.getDownloadURL();
+        await storageRef.delete();
+
+        final resultCall = storage.refFromURL(url).getDownloadURL;
+
+        expect(
+          () async => await resultCall(),
+          throwsA(isA<FirebaseException>()),
+        );
+      },
+    );
     test('Set, get and update metadata', () async {
       final storage = MockFirebaseStorage();
       final storageRef = storage.ref().child(filename);


### PR DESCRIPTION
# getDownloadURL() function now returns url only if object is in the storage already

- Have added checks in the getDownloadURL() which check if the object is already stored in the MockFirebaseStorage. If the object is present in storage only then a url is returned otherwise a FirebaseException will be thrown.
- Have added a "Delete File" test which expects a FirebaseException to be thrown when getDownloadURL() is called on a non-existent object.
- Have modified the "Get download url" and "Ref from url" test to first store a file in storage and then call getDownloadURL() on it so FirebaseException is not thrown.
