### PR TITLE
Bump firebase_storage dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_storage: ^12.0.0
+  firebase_storage: ^13.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Outdated dependencies are blocking the update to the latest flutterfire packages.