### PR TITLE
Fix Reference.fullPath to return the bucket-relative slash-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed `Reference.fullPath` to return the bucket-relative slash-path (e.g. `images/photo.png`) instead of a `gs://{bucket}{path}` URI, matching real Firebase Storage. The leading slash is also stripped.
+
 ## 0.8.0+1
 
 - Upgraded dependency to firebase_storage 12.0.0. [PR-44](https://github.com/atn832/firebase_storage_mocks/pull/44). Thank you [jt274](https://github.com/jt274)!

--- a/lib/src/mock_storage_reference.dart
+++ b/lib/src/mock_storage_reference.dart
@@ -67,7 +67,12 @@ class MockReference implements Reference {
 
   @override
   String get fullPath {
-    return 'gs://${_storage.bucket}$_path';
+    // Real Firebase Storage returns the bucket-relative slash-path here
+    // (e.g. `images/someimage.png`), NOT a `gs://{bucket}` URI. The leading
+    // slash is also stripped to match real `Reference.fullPath`, where the
+    // root reference's `fullPath` is the empty string. See
+    // https://firebase.google.com/docs/reference/js/storage.reference.md#referencefullpath
+    return _path.startsWith('/') ? _path.substring(1) : _path;
   }
 
   @override

--- a/test/firebase_storage_mocks_test.dart
+++ b/test/firebase_storage_mocks_test.dart
@@ -20,7 +20,7 @@ void main() {
       await task;
 
       expect(
-          task.snapshot.ref.fullPath, equals('gs://some-bucket/someimage.png'));
+          task.snapshot.ref.fullPath, equals('someimage.png'));
       expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
     });
 
@@ -32,7 +32,7 @@ void main() {
       await task;
 
       expect(
-          task.snapshot.ref.fullPath, equals('gs://some-bucket/someimage.png'));
+          task.snapshot.ref.fullPath, equals('someimage.png'));
       expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
     });
     // test for putString
@@ -43,9 +43,29 @@ void main() {
       await task;
 
       expect(
-          task.snapshot.ref.fullPath, equals('gs://some-bucket/someimage.png'));
+          task.snapshot.ref.fullPath, equals('someimage.png'));
       expect(storage.storedDataMap.containsKey('/$filename'), isTrue);
       expect(storage.storedDataMap.get('/$filename'), equals('some string'));
+    });
+    group('fullPath returns the bucket-relative slash-path', () {
+      // Real Firebase Storage's `Reference.fullPath` is the path relative to
+      // the bucket root with no `gs://{bucket}` prefix and no leading slash.
+      // These tests pin that contract so the mock stays faithful to it.
+      test('for a top-level child', () {
+        final storage = MockFirebaseStorage();
+        final ref = storage.ref().child(filename);
+        expect(ref.fullPath, equals('someimage.png'));
+      });
+      test('for a nested path', () {
+        final storage = MockFirebaseStorage();
+        final ref = storage.ref('/images').child('/$filename');
+        expect(ref.fullPath, equals('images/someimage.png'));
+      });
+      test('has no gs:// prefix', () {
+        final storage = MockFirebaseStorage();
+        final ref = storage.ref().child(filename);
+        expect(ref.fullPath.startsWith('gs://'), isFalse);
+      });
     });
     group('Gets Data', () {
       late MockFirebaseStorage storage;


### PR DESCRIPTION
## Problem

`MockReference.fullPath` returns a `gs://{bucket}{path}` URI:

```dart
String get fullPath {
  return 'gs://${_storage.bucket}$_path';
}
```

But real Firebase Storage's [`Reference.fullPath`](https://firebase.google.com/docs/reference/js/storage.reference.md#referencefullpath) returns the **bucket-relative slash-path** — no `gs://{bucket}` prefix and no leading slash. For example, `storage.ref().child('images/photo.png').fullPath` is `images/photo.png`, not `gs://some-bucket/images/photo.png`.

Because the path is concatenated without a separator, a nested ref like `storage.ref('/images').child('/photo.png')` even produced `gs://some-bucketimages/photo.png` under the mock.

This bites downstream code that synthesises its own `gs://{bucket}/{fullPath}` URIs from a reference: under the mock it yields a doubled `gs://some-bucket/gs://some-bucket...` prefix that never occurs against real Storage, forcing tests to encode the quirk.

## Fix

`fullPath` now strips the `gs://{bucket}` prefix and the leading slash, returning the bucket-relative slash-path that matches real Firebase.

- Updated the existing `fullPath` expectations (`gs://some-bucket/someimage.png` → `someimage.png`).
- Added tests pinning the slash-path contract for top-level and nested refs, and asserting there is no `gs://` prefix.

All tests pass (`flutter test` → 19 passing).